### PR TITLE
Refactor last commit

### DIFF
--- a/dot-files/bashrc
+++ b/dot-files/bashrc
@@ -6,16 +6,21 @@ set -o vi
 
 sourceIfExists(){
   local ALL=$@
+  local IGNORED_FILES=".bash_profile .bash_history"
   for TARGET in ${ALL}
   do
-    [ -f ${TARGET} ] && source ${TARGET}
+    TARGET_BASENAME=$(basename ${TARGET})
+    IS_IGNORED=$(echo ${IGNORED_FILES} | grep ${TARGET_BASENAME})
+    if [ -z "${IS_IGNORED}" ]
+    then
+      [ -f ${TARGET} ] && source ${TARGET}
+    fi
   done
 }
 
 # Import configurations
-sourceIfExists ~/.bash_[^hp]*
-sourceIfExists ~/.git-prompt.sh
-sourceIfExists ~/.git-completion.bash
+sourceIfExists ~/.bash_*
+sourceIfExists ~/.git-*
 
 # colors!
 green="\e[32m"


### PR DESCRIPTION
Instead of going like before using the glob pattern did mean that any other file with this naming 👇 
```
bash_[h]ello
bash_[h]ide
bash_[p]resent
bash_[p]pita
```
wont be sourced so instead of doing that I decided (With the help of a mate) that it will be better to just ignore the `bash_profile` and `bash_history` files inside the `forloop` of the function `sourceIfExists` which were making the terminal go nuts.

The initial issue was that when you source the `bash_history` all your previous commands execute right away 💥 💣 🤷‍♂️ 

